### PR TITLE
Add an Attribution Banner to Map with Contribution Link

### DIFF
--- a/cypress/e2e/map.cy.ts
+++ b/cypress/e2e/map.cy.ts
@@ -95,4 +95,19 @@ describe("Map", () => {
 
     cy.url().should("not.contain", "lng=-82.401078");
   });
+
+  it.only("Attribution control displays the proper message and link", () => {
+    loadMap("/");
+
+    cy.get(".leaflet-control-attribution").contains(
+      "Brought to you by HackGreenville Labs. Click here to contribute!"
+    );
+
+    // Get contribution link and ensure that the URL is as expected
+    cy.get(
+      ".leaflet-control-container > div.leaflet-bottom.leaflet-right > div > a:nth-child(2)"
+    )
+      .should("have.attr", "href")
+      .and("match", /https:\/\/data.openupstate.org\/contribute/);
+  });
 });

--- a/cypress/e2e/map.cy.ts
+++ b/cypress/e2e/map.cy.ts
@@ -96,7 +96,7 @@ describe("Map", () => {
     cy.url().should("not.contain", "lng=-82.401078");
   });
 
-  it.only("Attribution control displays the proper message and link", () => {
+  it("Attribution control displays the proper message and link", () => {
     loadMap("/");
 
     cy.get(".leaflet-control-attribution").contains(

--- a/src/@vue-leaflet/vue-leaflet.d.ts
+++ b/src/@vue-leaflet/vue-leaflet.d.ts
@@ -2,4 +2,5 @@ declare module "@vue-leaflet/vue-leaflet" {
   import type { DefineComponent } from "vue";
   export const LMap: DefineComponent;
   export const LTileLayer: DefineComponent;
+  export const LControlAttribution: DefineComponent;
 }

--- a/src/components/MainMap.vue
+++ b/src/components/MainMap.vue
@@ -5,7 +5,11 @@ import type { Map, GeoJSON, LayersControlEvent } from "leaflet";
 </script>
 
 <script setup lang="ts">
-import { LMap, LTileLayer } from "@vue-leaflet/vue-leaflet";
+import {
+  LMap,
+  LTileLayer,
+  LControlAttribution,
+} from "@vue-leaflet/vue-leaflet";
 import { useMapStore } from "../stores/map";
 import { useRoute, useRouter } from "vue-router";
 import type { Feature } from "geojson";
@@ -203,13 +207,21 @@ function toTitleCase(string: string) {
       :minZoom="7"
       :maxZoom="20"
       :center="mapStore.locationArray"
+      :options="{
+        attributionControl: false,
+      }"
       @ready="initializeMap"
     >
+      <l-control-attribution
+        position="bottomright"
+        prefix="Brought to you by <a href='https://hackgreenville.com/'>HackGreenville Labs</a>. <a href='https://data.openupstate.org/contribute'>Click here</a> to contribute!"
+      />
       <l-tile-layer
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         layer-type="base"
         name="OpenStreetMap"
-      ></l-tile-layer>
+        attribution="© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors"
+      />
     </l-map>
   </div>
 </template>


### PR DESCRIPTION
# Summary
Adds an attribution control element to the bottom-right corner of the map. It lets anyone who navigates to the homepage know who is behind the project and where they can go to get involved.

I've also added in attribution to OpenStreetMap for the base layer.


# Screenshots

## Desktop
![Screenshot_2023-10-07_23-47-58](https://github.com/hackgvl/open-map-data-multi-layers-demo/assets/44626690/0bccd8d3-3929-44ac-b785-2096e0f6ffd2)

## Mobile
![Screenshot_2023-10-07_23-45-21](https://github.com/hackgvl/open-map-data-multi-layers-demo/assets/44626690/1242b912-c98f-45d0-8f4e-1dbce4d869c8)


# Testing Plan
1. The attribution control bar will be visible in the bottom-right corner of the map whenever the main page is loaded.
2. Ensure that the three hyperlinks contained within all are oeprational and take you to the expected pages.