### PR TITLE
Add CI status badge and move to top.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,6 @@
 
 // Ignore bundle files
 dist/*
+
+// Ignore the README to avoid conflicts with the All Contributors bot
+README.md

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Open Data Upstate / Greenville SC Map Layers Demo
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-
 [all-contributors-logo]: https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square "Number of contributors on All-Contributors"
-
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![All Contributors][all-contributors-logo]](#contributors-)&ensp;[![Continuous Integration](https://github.com/hackgvl/open-map-data-multi-layers-demo/actions/workflows/ci.yml/badge.svg)](https://github.com/hackgvl/open-map-data-multi-layers-demo/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
+[all-contributors-logo]: https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square "Number of contributors on All-Contributors"
 
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
+
+[![All Contributors][all-contributors-logo]](#contributors-)&ensp;[![Continuous Integration](https://github.com/hackgvl/open-map-data-multi-layers-demo/actions/workflows/ci.yml/badge.svg)](https://github.com/hackgvl/open-map-data-multi-layers-demo/actions/workflows/ci.yml)
 
 This is a Vue project which allows all you to dynamically toggle on/off any of
 the [Upstate / Greenville SC open map data
@@ -117,14 +119,6 @@ npm run lint
 ```
 
 ---
-
-`stable`:
-
-[![run-tests](https://github.com/hackgvl/open-map-data-multi-layers-demo/actions/workflows/run-tests.yml/badge.svg?branch=stable)](https://github.com/hackgvl/open-map-data-multi-layers-demo/actions/workflows/run-tests.yml)
-
-`develop`:
-
-[![run-tests](https://github.com/hackgvl/open-map-data-multi-layers-demo/actions/workflows/run-tests.yml/badge.svg?branch=develop)](https://github.com/hackgvl/open-map-data-multi-layers-demo/actions/workflows/run-tests.yml)
 
 ## Contributors ✨
 


### PR DESCRIPTION
Remove the two "run-tests" status badges since that workflow is no longer in use.

Moves the CI status badge to the top next to the All Contributors contributor count badge.