### PR TITLE
Add upload-artifact step to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,15 @@ jobs:
         run: npm run test:unit
 
       - name: Run end-to-end tests
+        id: e2eTests
         run: npm run test:e2e
+
+      # Uploads the failure screenshots produced by Cypress
+      - uses: actions/upload-artifact@v3
+        if: always() && (steps.e2eTests.outcome == 'failure')
+        name: Upload Cypress failure screenshots
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots/**/*.png
+          if-no-files-found: ignore
+          retention-days: 1


### PR DESCRIPTION
Fixes #21 

# Summary
Uploads screenshots of test failures produced by Cypress in CI workflows.

They can be found in the "Artifacts" section of the summary pages of runs that have had e2e test failures.
![Screenshot_2023-10-08_19-51-32](https://github.com/hackgvl/open-map-data-multi-layers-demo/assets/44626690/ebcd072d-6b41-46cb-9211-1b41e184bdce)

These can be downloaded for use with troubleshooting test failures.

**[Example Workflow Summary with Artifacts](https://github.com/hackgvl/open-map-data-multi-layers-demo/actions/runs/6450696317)**
