### PR TITLE
Retain Markers and Layers Whenever Leaving and Returning to Map Page

### DIFF
--- a/cypress/e2e/map.cy.ts
+++ b/cypress/e2e/map.cy.ts
@@ -74,7 +74,7 @@ describe("Map", () => {
     cy.url().should("not.contain", "lng=-82.401078");
   });
 
-  it.only("Map contents are redisplayed whenever returning to the page from another", () => {
+  it("Map contents are redisplayed whenever returning to the page from another", () => {
     loadMap("/?maps=adult-day-care");
 
     cy.get(".leaflet-marker-icon").its("length").as("initialNumberOfMarkers");
@@ -108,7 +108,7 @@ describe("Map", () => {
       loadMap("/");
 
       cy.get(".leaflet-control-attribution").contains(
-        "Brought to you by HackGreenville Labs.",
+        "Brought to you by HackGreenville Labs",
       );
     });
   });

--- a/cypress/e2e/map.cy.ts
+++ b/cypress/e2e/map.cy.ts
@@ -74,6 +74,35 @@ describe("Map", () => {
     cy.url().should("not.contain", "lng=-82.401078");
   });
 
+  it.only("Map contents are redisplayed whenever returning to the page from another", () => {
+    loadMap("/?maps=adult-day-care");
+
+    cy.get(".leaflet-marker-icon").its("length").as("initialNumberOfMarkers");
+
+    // Go to the About page...
+    cy.contains("About").click();
+    // ... and then back to the map page.
+    cy.get("nav > a:nth-child(1)").click();
+
+    // Check that the markers are all still there
+    cy.get("@initialNumberOfMarkers").then((initialCount) => {
+      cy.get(".leaflet-marker-icon")
+        .its("length")
+        .then((newCount) => {
+          expect(initialCount).to.eq(newCount);
+        });
+    });
+
+    cy.url().should("contain", "maps=adult-day-care");
+
+    // Check that the layer checkbox is still checked
+    cy.get("[title='Layers']").trigger("mouseover");
+    cy.get(".leaflet-control-layers-overlays label input[checked]").should(
+      "have.length",
+      1,
+    );
+  });
+
   describe("Attribution Control", () => {
     it("Attribution control displays the proper message", () => {
       loadMap("/");

--- a/src/stores/map.ts
+++ b/src/stores/map.ts
@@ -7,7 +7,7 @@ import type {
   LayerData,
   MaintainerData,
 } from "../types";
-import type { LatLng } from "leaflet";
+import L, { type LatLng } from "leaflet";
 
 export const useMapStore = defineStore("map", {
   state: () => ({
@@ -100,6 +100,18 @@ export const useMapStore = defineStore("map", {
       }
 
       return this.availableMaps;
+    },
+    /*
+     * Resets the layer feature collection, while retaining options
+     * (for things like the styling of the marker and the pointToLayer
+     *  and onEachFeature callbacks) to prevent memory leaks from occurring.
+     */
+    async clearLayerData() {
+      for (const key in this.loadedMaps) {
+        this.loadedMaps[key].layer = new L.GeoJSON(undefined, {
+          ...this.loadedMaps[key].layer.options,
+        });
+      }
     },
   },
 });

--- a/src/tests/stores/map.spec.ts
+++ b/src/tests/stores/map.spec.ts
@@ -146,4 +146,59 @@ describe("mapStore", () => {
     mapStore.removeMapLayer(fakeMapSlug);
     expect(mapStore.loadedMaps).toStrictEqual({});
   });
+
+  describe("clearLayerData", () => {
+    it("clears feature collection and retains options from previous copy of layer", async () => {
+      const featureCollection: GeoJSON.FeatureCollection<any> = {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            geometry: {
+              type: "Point",
+              coordinates: [0, 0],
+            },
+            properties: {},
+          },
+        ],
+      };
+
+      const mapStore = useMapStore();
+      const layerData: LayerData = {
+        layer: L.geoJSON(featureCollection, {
+          style: () => ({
+            fillColor: "test",
+            color: "test",
+          }),
+        }),
+        loaded: false,
+        visible: false,
+      };
+
+      mapStore.addMapLayer(fakeMapSlug, layerData, sampleMaintainerData);
+
+      const beforeKeyCount = Object.keys(
+        mapStore.loadedMaps[fakeMapSlug].layer,
+      ).length;
+
+      await mapStore.clearLayerData();
+
+      const afterKeyCount = Object.keys(
+        mapStore.loadedMaps[fakeMapSlug].layer,
+      ).length;
+
+      expect(beforeKeyCount).toBeGreaterThan(afterKeyCount);
+
+      expect(typeof layerData.layer.options.style).toEqual("function");
+
+      if (typeof layerData.layer.options.style == "function") {
+        expect(JSON.stringify(layerData.layer.options.style())).toEqual(
+          JSON.stringify({
+            fillColor: "test",
+            color: "test",
+          }),
+        );
+      }
+    });
+  });
 });

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -1,0 +1,63 @@
+import L, { LatLng } from "leaflet";
+import type { Feature } from "geojson";
+import type { GeoJSON } from "leaflet";
+
+export function createMarker(color: string, latlng: LatLng) {
+  const markerHtmlStyles = `
+    background-color: ${color};
+    width: 2rem;
+    height: 2rem;
+    display: block;
+    left: -1rem;
+    top: -1rem;
+    position: relative;
+    border-radius: 2rem 2rem 0;
+    transform: rotate(45deg);
+    border: 1px solid #FFFFFFAA`;
+
+  const markerIcon = L.divIcon({
+    className: "",
+    iconAnchor: [0, 24],
+    popupAnchor: [0, -36],
+    html: `<span style="${markerHtmlStyles}" />`,
+  });
+
+  return L.marker(latlng, { icon: markerIcon });
+}
+
+export function setTooltips(
+  mapTitle: string,
+  feature: Feature,
+  layer: GeoJSON,
+) {
+  if (feature && feature.properties) {
+    const properties = feature.properties;
+
+    const tooltipString =
+      `<div>Map: ${mapTitle}</div>` +
+      Object.keys(properties)
+        .filter((key) => key != "OBJECTID" && properties[key])
+        .map((key) => {
+          const propertyName = toTitleCase(key.toString()).replace(/_/g, " ");
+          let propertyValue;
+          if (
+            properties[key]?.toString().startsWith("http") ||
+            properties[key]?.toString().startsWith("tel")
+          ) {
+            propertyValue = `<a href="${properties[key]}" target="_blank" rel="noreferrer">${properties[key]}</a>`;
+          } else {
+            propertyValue = properties[key];
+          }
+
+          return `<div>${propertyName}: ${propertyValue}</div>`;
+        })
+        .join("");
+    layer.bindPopup(tooltipString, {});
+  }
+}
+
+function toTitleCase(string: string) {
+  return string.replace(/\w\S*/g, function (txt) {
+    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+  });
+}


### PR DESCRIPTION
Fixes #25 

# Summary
Fixes an issue where whenever a user would go to the About page from the Map page and then back:
- Any markers that were on the map were absent
- Hovering over the layers control produced a shriveled icon- all layer options were gone
- Users would need to refresh the page to see map data once again

# Testing
1. Enable some map layers
2. Go to the About page
3. Navigate back to the map page
   1. All of your active layers should be represented in:
       1. The markers the appear on the map
       2. The query parameters in the URL
       3. The layer control should have the checkboxes for these layers still checked (and the unchecked ones should appear also)
       4. The maintainer info in visible in that control as well
4. Flip back and forth between the Map and About pages to ensure that performance does not degrade

**Bonus:**
1. Take [fuite](https://github.com/nolanlawson/fuite/) for a spin to ensure there aren't any glaring memory leaks pertaining to step 4 above.
```bash
npx fuite http://localhost:4173/open-map-data-multi-layers-demo/\?lat\=34.84240835693139\&lng\=-82.4626922607422\&zoom\=12\&maps\=city-halls,breweries --iterations 10
```
2. Compare your results with the live version at https://hackgvl.github.io/open-map-data-multi-layers-demo to make sure no new issues stem from these changes.

# Thank you!